### PR TITLE
Better performance and resliancy in high-concurrency settings

### DIFF
--- a/is-master.js
+++ b/is-master.js
@@ -116,6 +116,8 @@ im.prototype.startWorker = function() {
                 memory: process.memoryUsage(),
                 uptime: process.uptime(),
                 updateDate: new Date()
+            }, {
+                upsert: true // handle event where document was deleted
             }, function(err, results) {
                 if (err) return console.error(err);
             });
@@ -137,7 +139,10 @@ im.prototype.isMaster = function(callback) {
             }
         }, function(err, results) {
             if (err) return callback(err);
-            if (results._id.toString() === _this.id.toString()) {
+
+            if(!results){
+              return callback(err, false);
+            } else if (results._id.toString() === _this.id.toString()) {
                 callback(err, true);
             } else {
                 callback(err, false);

--- a/is-master.js
+++ b/is-master.js
@@ -73,7 +73,13 @@ im.prototype.mongooseInit = function() {
         }
     });
 
-    this.imModel = mongoose.model(this.collection, imSchema);
+    // ensure we aren't attempting to redefine a collection that already exists
+    if(mongoose.models.hasOwnProperty(this.collection)){
+        this.imModel = mongoose.model(this.collection);
+    }else{
+        this.imModel = mongoose.model(this.collection, imSchema);
+    }
+
     this.worker = new this.imModel({
         hostname: this.hostname,
         pid: this.pid,


### PR DESCRIPTION
I added support for handling the case when a model has already been registered for this collection. This can occur if this module is instantiated multiple times simultaneously. This happens for us during automated testing.

In the event that the collection is modified directly in the database, I added the upsert flag and handled the event when no results are returned from the query. Both of these were crashers in the event that someone modified the collection directly.
