### PR TITLE
Change .update to .updateOne

### DIFF
--- a/is-master.js
+++ b/is-master.js
@@ -133,7 +133,7 @@ im.prototype.process = function() {
     var _this = this;
     // Update this node in the cluster every x timeout
     setInterval(function() {
-        _this.imModel.update({
+        _this.imModel.updateOne({
             _id: _this.id
         }, {
             hostname: _this.hostname,


### PR DESCRIPTION
* Changed _this.imModel.update to updateOne in order to fix deprecation issues in the latest deprecation warnings in Mongoose.

