### PR TITLE
Rename `slave` to `secondary`.

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,8 +60,8 @@ im.on('master', function() {
     console.log('The process has been promoted to master');
 });
 
-im.on('slave', function(){
-    console.log('The process has been demoted to slave');
+im.on('secondary', function(){
+    console.log('The process has been demoted to secondary');
 });
 ```
 
@@ -80,6 +80,12 @@ When starting the worker, you can specify options in an object to update the def
 Q. I updated the timeout option, but mongodb is not expiring the node in that timeout specified.
 
 A. 60 seconds is added to the mongodb expire timeout to ensure the master has time to checkin. Also please note, if this value is changed from the initial creation of the table, it will not be able to update the index. You will need to delete the table and then restart your server to re-create it.
+
+
+## Compatibility
+
+For backward compatibility, the `secondary` event is also emitted with the historical name `slave`.
+This maybe removed in a future release.
 
 ## More info
 

--- a/examples/example.js
+++ b/examples/example.js
@@ -44,6 +44,6 @@ im.on('master', function() {
     console.log('The process has been promoted to master');
 });
 
-im.on('slave', function(){
-    console.log('The process has been demoted to slave');
+im.on('secondary', function(){
+    console.log('The process has been demoted to secondary');
 });

--- a/is-master.js
+++ b/is-master.js
@@ -120,6 +120,7 @@ im.prototype.startWorker = function() {
                 _this.emit('master');
             } else {
                 _this.emit('slave');
+                _this.emit('secondary');
             }
             _this.process();
         });
@@ -157,6 +158,7 @@ im.prototype.process = function() {
                         _this.emit('master');
                     } else {
                         _this.emit('slave');
+                        _this.emit('secondary');
                     }
                 }
             });

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "multi",
     "server",
     "isMaster",
-    "isSlave",
+    "isSecondary",
     "heartbeat"
   ],
   "author": "Matt Atkinson <mattpker@gmail.com> (https://github.com/mattpker)",


### PR DESCRIPTION
Drupal, Django, MongoDB, Salt and other projects have already moved away from
using the term `slave` as part of building a more inclusive community of
developers.

https://en.wikipedia.org/wiki/Master/slave_(technology)#Terminology_concerns

Terms like "secondary", "replica" or "minion" are used instead and are
well understood at this point as comparable technical concepts.